### PR TITLE
Fix the Linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-        # TODO: Fix Linux build again
-        # - ubuntu-latest
+        - ubuntu-latest
         - macos-latest
         swift: ['5.8']
 

--- a/Sources/DNSServiceDiscovery/IPAddress.swift
+++ b/Sources/DNSServiceDiscovery/IPAddress.swift
@@ -11,7 +11,11 @@ public enum IPAddress: Hashable {
         case (.ipv4(let l), .ipv4(let r)):
             return l.s_addr == r.s_addr
         case (.ipv6(let l), .ipv6(let r)):
+            #if os(Linux)
+            return l.__in6_u.__u6_addr32 == r.__in6_u.__u6_addr32
+            #else
             return l.__u6_addr.__u6_addr32 == r.__u6_addr.__u6_addr32
+            #endif
         default:
             return false
         }
@@ -22,7 +26,11 @@ public enum IPAddress: Hashable {
         case .ipv4(let addr):
             addr.s_addr.hash(into: &hasher)
         case .ipv6(let addr):
+            #if os(Linux)
+            let (x0, x1, x2, x3) = addr.__in6_u.__u6_addr32
+            #else
             let (x0, x1, x2, x3) = addr.__u6_addr.__u6_addr32
+            #endif
             x0.hash(into: &hasher)
             x1.hash(into: &hasher)
             x2.hash(into: &hasher)

--- a/Sources/DNSServiceDiscovery/Internal/DNSService+GetAddrInfo.swift
+++ b/Sources/DNSServiceDiscovery/Internal/DNSService+GetAddrInfo.swift
@@ -1,3 +1,5 @@
+#if canImport(Darwin)
+
 import CDNSSD
 
 private typealias Identifier = UnsafeMutableRawPointer
@@ -55,3 +57,5 @@ extension DNSService {
         return DNSService(identifierBox: identifierBox, wrappedRef: serviceRef)
     }
 }
+
+#endif

--- a/Sources/DNSServiceDiscovery/Internal/DNSService+NetworkProtocol.swift
+++ b/Sources/DNSServiceDiscovery/Internal/DNSService+NetworkProtocol.swift
@@ -1,0 +1,14 @@
+#if canImport(Darwin)
+
+import CDNSSD
+
+extension DNSService {
+    enum NetworkProtocol: CDNSSD.DNSServiceProtocol, Hashable {
+        case ipv4 = 0x01 // kDNSServiceProtocol_IPv4
+        case ipv6 = 0x02 // kDNSServiceProtocol_IPv6
+        case udp  = 0x10 // kDNSServiceProtocol_UDP
+        case tcp  = 0x20 // kDNSServiceProtocol_TCP
+    }
+}
+
+#endif

--- a/Sources/DNSServiceDiscovery/NetworkProtocol.swift
+++ b/Sources/DNSServiceDiscovery/NetworkProtocol.swift
@@ -1,8 +1,0 @@
-import CDNSSD
-
-public enum NetworkProtocol: CDNSSD.DNSServiceProtocol, Hashable {
-    case ipv4 = 0x01 // kDNSServiceProtocol_IPv4
-    case ipv6 = 0x02 // kDNSServiceProtocol_IPv6
-    case udp  = 0x10 // kDNSServiceProtocol_UDP
-    case tcp  = 0x20 // kDNSServiceProtocol_TCP
-}


### PR DESCRIPTION
This reenables the Linux build by conditionally compiling the parts of the DNS-SD API that aren't available and fixes the IP-Address-related issues.