### PR TITLE
Add support for host name resolution

### DIFF
--- a/Sources/DNSServiceDiscovery/DNSServiceInstance.swift
+++ b/Sources/DNSServiceDiscovery/DNSServiceInstance.swift
@@ -8,6 +8,8 @@ public struct DNSServiceInstance: Hashable {
     public var domain: Domain
     /// The interface index on which the service was discovered.
     public var interfaceIndex: UInt32
+    /// The host name of discovered instance machine.
+    public var host: String?
     /// The port on which the instance is running.
     public var port: UInt16? = nil
     /// The TXT record key-value pairs. Only provided during resolution.

--- a/Sources/DNSServiceDiscovery/Internal/DNSService+Resolve.swift
+++ b/Sources/DNSServiceDiscovery/Internal/DNSService+Resolve.swift
@@ -62,12 +62,14 @@ extension DNSService {
                 var flags = Flags(rawValue: rawFlags)
                 flags.insert(.add) // We always consider resolved instances "added" so we can deal with them in a uniform way on a higher level
 
+                let hostName = rawHostTarget.map { String(cString: $0) }
                 let txtRecord = rawTxtRecord.map { parse(rawTxtRecord: $0, txtLen: Int(txtLen)) } ?? [:]
                 let instance = DNSServiceInstance(
                     name: resolveQuery.name,
                     type: resolveQuery.serviceType,
                     domain: resolveQuery.domain,
                     interfaceIndex: interfaceIndex,
+                    host: hostName,
                     port: UInt16(bigEndian: port), // Convert from network byte order
                     txtRecord: txtRecord
                 )


### PR DESCRIPTION
Looks like only port was resolved into `DNSServiceInstance` during DNS resolution. This PR adds a host name too.
